### PR TITLE
Improve setup script (add users, groups, & udev rules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nano /etc/wpa_supplicant/wpa_supplicant.conf
 [ Add the following two lines to top of file ]
 
 ```plaintext
-ctrl_interface=/run/wpa_supplicant
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=wpactrl-user
 update_config=1
 ```
 

--- a/conf/50-gpio.rules
+++ b/conf/50-gpio.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio-user /dev/gpiochip* ; chmod -R 770 /dev/gpiochip*'"

--- a/conf/50-i2c.rules
+++ b/conf/50-i2c.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="i2c-dev", GROUP="i2c-user", MODE="0660"

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -71,10 +71,10 @@ if args.i2c:
 if args.rtc and args.i2c:
     if args.rtc == "ds1307":
         print("[ CONFIGURING DS1307 RTC MODULE ]")
-        subprocess.call(["cp", "conf/config.txt_rtc1307", "/boot/firmware/config.txt"])
+        subprocess.call(["cp", "conf/config.txt_ds1307", "/boot/firmware/config.txt"])
     elif args.rtc == "ds3231":
         print("[ CONFIGURING DS3231 RTC MODULE ]")
-        subprocess.call(["cp", "conf/config.txt_rtc3231", "/boot/firmware/config.txt"])
+        subprocess.call(["cp", "conf/config.txt_ds3231", "/boot/firmware/config.txt"])
     subprocess.call(["cp", "conf/modules_rtc", "/etc/modules"])
     subprocess.call(["cp", "conf/activate_rtc.sh", "/usr/local/bin/activate_rtc"])
     subprocess.call(["cp", "conf/activate-rtc.service", "/etc/systemd/system/activate-rtc.service"])

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -40,6 +40,7 @@ subprocess.call(["/usr/sbin/adduser", username])
 subprocess.call(["usermod", "-aG", "sudo", username])
 
 print("[ CREATING SYSTEM GROUPS ]")
+subprocess.call(["/usr/sbin/groupadd", "peach"])
 subprocess.call(["/usr/sbin/groupadd", "i2c-user"])
 subprocess.call(["/usr/sbin/groupadd", "gpio-user"])
 subprocess.call(["/usr/sbin/groupadd", "wpactrl-user"])


### PR DESCRIPTION
This pull-request enacts the enhancement outlined in this issue: [Create system users for services in setup script](https://github.com/peachcloud/peach-config/issues/4)

System users are added for all peach-* microservices and added to appropriate groups. This opens the way to update all systemd unit files (in microservice repos) to run as discreet users.

This PR also adds udev rules to grant I2C, GPIO and network access to relevant groups.

Finally, typos have been fixed in the naming of RTC config files.