### PR TITLE
Fix i2c

### DIFF
--- a/conf/50-i2c.rules
+++ b/conf/50-i2c.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="i2c-dev", GROUP="i2c-user", MODE="0660"

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -41,7 +41,6 @@ subprocess.call(["usermod", "-aG", "sudo", username])
 
 print("[ CREATING SYSTEM GROUPS ]")
 subprocess.call(["/usr/sbin/groupadd", "peach"])
-subprocess.call(["/usr/sbin/groupadd", "i2c-user"])
 subprocess.call(["/usr/sbin/groupadd", "gpio-user"])
 subprocess.call(["/usr/sbin/groupadd", "wpactrl-user"])
 

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -66,7 +66,6 @@ if args.i2c:
     subprocess.call(["cp", "conf/mygpio.dtbo", "/boot/firmware/overlays/mygpio.dtbo"])
     subprocess.call(["cp", "conf/config.txt_i2c", "/boot/firmware/config.txt"])
     subprocess.call(["cp", "conf/modules", "/etc/modules"])
-    subprocess.call(["cp", "conf/50-i2c.rules", "/etc/udev/rules.d/50-i2c.rules"])
 
 if args.rtc and args.i2c:
     if args.rtc == "ds1307":

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -51,7 +51,7 @@ for user in users:
     subprocess.call(["/usr/sbin/adduser", "--system", "--no-create-home", "--ingroup", "peach", user])
 
 print("[ ASSIGNING GROUP MEMBERSHIP ]")
-subprocess.call(["/usr/sbin/usermod", "-a", "-G", "i2c-user", "peach-oled"])
+subprocess.call(["/usr/sbin/usermod", "-a", "-G", "i2c", "peach-oled"])
 subprocess.call(["/usr/sbin/usermod", "-a", "-G", "gpio-user", "peach-buttons"])
 subprocess.call(["/usr/sbin/usermod", "-a", "-G", "wpactrl-user", "peach-network"])
 


### PR DESCRIPTION
Remove creation of the `i2c-user` group from the setup script and instead assign the `peach-oled` user to the preexisting `i2c` system group. This allows i2c access as the `peach-oled` user without having to create additional udev rules.