### PR TITLE
Update network scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-config
 
-![Generic badge](https://img.shields.io/badge/version-0.2.1-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-0.2.2-<COLOR>.svg)
 
 Configuration instructions, files and scripts for deploying PeachCloud. 
 

--- a/conf/network
+++ b/conf/network
@@ -1,0 +1,14 @@
+#
+# Allow peach-network user to execute activate_ap and
+# activate_client scripts without needing to enter
+# a password for sudo'd command.
+#
+
+# User alias for PeachCloud microservices which initiate shutdown
+User_Alias  PEACH_NTWK = peach-network
+
+# Command alias for activate_ap and activate_client scripts
+Cmnd_Alias  SCRIPTS = /usr/local/bin/activate_ap, /usr/local/bin/activate_client
+
+# Allow PEACH_NTWK users to execute SCRIPTS commands without password
+PEACH_NTWK  ALL=(ALL) NOPASSWD: SCRIPTS

--- a/conf/network
+++ b/conf/network
@@ -4,11 +4,14 @@
 # a password for sudo'd command.
 #
 
-# User alias for PeachCloud microservices which initiate shutdown
+# User alias for PeachCloud microservices which control networking
 User_Alias  PEACH_NTWK = peach-network
 
 # Command alias for activate_ap and activate_client scripts
 Cmnd_Alias  SCRIPTS = /usr/local/bin/activate_ap, /usr/local/bin/activate_client
 
-# Allow PEACH_NTWK users to execute SCRIPTS commands without password
-PEACH_NTWK  ALL=(ALL) NOPASSWD: SCRIPTS
+# Command alias for network-related actions
+Cmnd_Alias  SERVICE = /usr/bin/systemctl unmask hostapd, /usr/bin/systemctl start hostapd, /usr/bin/systemctl stop hostapd, /usr/bin/systemctl stop dnsmasq, /usr/bin/systemctl start dnsmasq, /usr/bin/systemctl start wpa_supplicant, /usr/bin/systemctl stop wpa_supplicant, /usr/sbin/ifup wlan0, /usr/sbin/ifdown wlan0, /bin/ip link set wlan0 mode default
+
+# Allow PEACH_NTWK users to execute SCRIPTS & SERVICE commands without password
+PEACH_NTWK  ALL=(ALL) NOPASSWD: SCRIPTS, SERVICE

--- a/conf/shutdown
+++ b/conf/shutdown
@@ -6,7 +6,7 @@
 # User alias for PeachCloud microservices which initiate shutdown
 User_Alias  PEACH_CTRL = peach-menu, peach-web
 
-# Command alias for reboot and shutdwon
+# Command alias for reboot and shutdown
 Cmnd_Alias  SHUTDOWN = /sbin/reboot, /sbin/shutdown
 
 # Allow PEACH_CTRL users to execute SHUTDOWN commands without password

--- a/scripts/activate_ap.sh
+++ b/scripts/activate_ap.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 
 # Activate the software access point (AP)
-echo "Stopping wpa_supplicant"
+
 /usr/bin/systemctl stop wpa_supplicant
-echo "Setting wlan0 interface down"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to stop wpa_supplicant"
+fi
+
 /usr/sbin/ifdown wlan0
-echo "Unmasking hostapd"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to set wlan0 interface down"
+fi
+
 /usr/bin/systemctl unmask hostapd
-echo "Starting hostapd"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to unmask hostapd"
+fi
+
 /usr/bin/systemctl start hostapd
-echo "Starting dnsmasq"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to start hostapd"
+fi
+
 /usr/bin/systemctl start dnsmasq
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to start dnsmasq"
+fi
+
+echo "Access point activated successfully"

--- a/scripts/activate_ap.sh
+++ b/scripts/activate_ap.sh
@@ -5,6 +5,8 @@ echo "Stopping wpa_supplicant"
 /usr/bin/systemctl stop wpa_supplicant
 echo "Setting wlan0 interface down"
 /usr/sbin/ifdown wlan0
+echo "Unmasking hostapd"
+/usr/bin/systemctl unmask hostapd
 echo "Starting hostapd"
 /usr/bin/systemctl start hostapd
 echo "Starting dnsmasq"

--- a/scripts/activate_ap.sh
+++ b/scripts/activate_ap.sh
@@ -3,28 +3,36 @@
 # Activate the software access point (AP)
 
 /usr/bin/systemctl stop wpa_supplicant
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to stop wpa_supplicant"
-fi
+wpa=$?
 
 /usr/sbin/ifdown wlan0
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to set wlan0 interface down"
-fi
+ifdown=$?
 
 /usr/bin/systemctl unmask hostapd
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to unmask hostapd"
-fi
+unmask=$?
 
 /usr/bin/systemctl start hostapd
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to start hostapd"
-fi
+hostapd=$?
 
 /usr/bin/systemctl start dnsmasq
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to start dnsmasq"
-fi
+dnsmasq=$?
 
-echo "Access point activated successfully"
+if [[ "$wpa" -ne 0  ]] ; then
+    echo "Failed to stop wpa_supplicant"
+    exit 1
+elif [[ "$ifdown" -ne 0 ]] ; then
+    echo "Failed to set wlan0 down"
+    exit 1
+elif [[ "$unmask" -ne 0 ]] ; then
+    echo "Failed to unmask hostapd"
+    exit 1
+elif [[ "$hostapd" -ne 0 ]] ; then
+    echo "Failed to start hostapd"
+    exit 1
+elif [[ "$dnsmasq" -ne 0 ]] ; then
+    echo "Failed to start dnsmasq"
+    exit 1
+else
+    echo "Access point activated successfully"
+    exit 0
+fi

--- a/scripts/activate_client.sh
+++ b/scripts/activate_client.sh
@@ -3,28 +3,36 @@
 # Activate wireless client mode
 
 /usr/bin/systemctl stop hostapd
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to stop hostapd"
-fi
+hostapd=$?
 
 /usr/bin/systemctl stop dnsmasq
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to stop dnsmasq"
-fi
+dnsmasq=$?
 
 /usr/bin/systemctl start wpa_supplicant
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to start wpa_supplicant"
-fi
+wpa=$?
 
 /usr/sbin/ifup wlan0
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to set wlan0 interface up"
-fi
+ifup=$?
 
 /bin/ip link set wlan0 mode default
-if [[ $? -ne 0  ]] ; then
-    echo "Failed to set wlan0 interface mode to default"
-fi
+mode=$?
 
-echo "Wireless client mode activated successfully"
+if [[ "$hostapd" -ne 0  ]] ; then
+    echo "Failed to stop hostapd"
+    exit 1
+elif [[ "$dnsmasq" -ne 0 ]] ; then
+    echo "Failed to stop dnsmasq"
+    exit 1
+elif [[ "$wpa" -ne 0 ]] ; then
+    echo "Failed to start wpa_supplicant"
+    exit 1
+elif [[ "$ifup" -ne 0 ]] ; then
+    echo "Failed to set wlan0 up"
+    exit 1
+elif [[ "$mode" -ne 0 ]] ; then
+    echo "Failed to set wlan0 mode to default"
+    exit 1
+else
+    echo "Wireless client mode activated successfully"
+    exit 0
+fi

--- a/scripts/activate_client.sh
+++ b/scripts/activate_client.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 
 # Activate wireless client mode
-echo "Stopping hostapd"
+
 /usr/bin/systemctl stop hostapd
-echo "Stopping dnsmasq"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to stop hostapd"
+fi
+
 /usr/bin/systemctl stop dnsmasq
-echo "Starting wpa_supplicant"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to stop dnsmasq"
+fi
+
 /usr/bin/systemctl start wpa_supplicant
-echo "Setting wlan0 interface up"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to start wpa_supplicant"
+fi
+
 /usr/sbin/ifup wlan0
-echo "Setting wlan0 to default mode"
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to set wlan0 interface up"
+fi
+
 /bin/ip link set wlan0 mode default
+if [[ $? -ne 0  ]] ; then
+    echo "Failed to set wlan0 interface mode to default"
+fi
+
+echo "Wireless client mode activated successfully"

--- a/scripts/activate_client.sh
+++ b/scripts/activate_client.sh
@@ -9,3 +9,5 @@ echo "Starting wpa_supplicant"
 /usr/bin/systemctl start wpa_supplicant
 echo "Setting wlan0 interface up"
 /usr/sbin/ifup wlan0
+echo "Setting wlan0 to default mode"
+/bin/ip link set wlan0 mode default

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -170,6 +170,7 @@ print("[ CONFIGURING SUDOERS ]")
 if not os.path.exists("/etc/sudoers.d"):
     os.mkdir("/etc/sudoers.d")
 subprocess.call(["cp", "conf/shutdown", "/etc/sudoers.d/shutdown"])
+subprocess.call(["cp", "conf/network", "/etc/sudoers.d/network"])
 
 print("[ PEACHCLOUD SETUP COMPLETE ]")
 

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -139,7 +139,13 @@ subprocess.call(["cp", "conf/00-accesspoint.rules",
                  "/etc/udev/rules.d/00-accesspoint.rules"])
 if not os.path.exists("/lib/systed/system/networking.service.d"):
     os.mkdir("/lib/systemd/system/networking.service.d")
-subprocess.call(["cp", "conf/reduce-timeout.conf", "/lib/systemd/system/networking.service.d/reduce-timeout.conf"])
+subprocess.call(["cp", "conf/reduce-timeout.conf",
+                 "/lib/systemd/system/networking.service.d/reduce-timeout.conf"])
+subprocess.call(["cp", "scripts/activate_ap.sh", "/usr/local/bin/activate_ap"])
+subprocess.call(["chmod", "755", "/usr/local/bin/activate_ap"])
+subprocess.call(["cp", "scripts/activate_client.sh",
+                 "/usr/local/bin/activate_client"])
+subprocess.call(["chmod", "755", "/usr/local/bin/activate_client"])
 # Allow group members to write to wpa_supplicant.conf
 subprocess.call(["chmod", "664", "/etc/wpa_supplicant/wpa_supplicant.conf"])
 # Set ownership so that wpa_supplicant.conf can be written to by peach-network


### PR DESCRIPTION
I recently realised that the `activate_ap` and `activate_client` RPC calls for `peach-network` were not working. In the code, the various commands which switch between access-point and client mode were being called with `sudo`. This worked previously when the `peach-network` service was being run as the `root` user. However, since updating `peach-network` to run as the `peach-network` system user, these sudo'd commands no longer work due to insufficient permissions.

In order to fix this, I have updated the `activate_ap.sh` and `activate_client.sh` scripts to execute the required commands and return an appropriate exit code and message. The [peach-network](https://github.com/peachcloud/peach-network) RPC calls can now be updated to call these scripts, rather than running the required commands individually. I have included a `NOPASSWD` `sudoers` configuration file to allow the scripts to be called by the `peach-network` user (with `sudo`) without needing to supply a password.

The added benefit of this configuration is that the `activate_ap` and `activate_client` scripts can be run independent of the `peach-network` microservice. This can prove quite useful during development and testing.

FYI: @mhfowler (this might be of interest to you)