### PR TITLE
Refactor setup_dev_env for idempotency

### DIFF
--- a/conf/peach.list
+++ b/conf/peach.list
@@ -1,0 +1,1 @@
+deb http://apt.peachcloud.org/ buster main

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -7,10 +7,11 @@
 
 import os
 import subprocess
-import sys
 import argparse
 
 from setup_networking import configure_networking
+from setup_peach_deb import setup_peach_deb
+from update_microservices import update_microservices
 
 # Setup argument parser
 parser = argparse.ArgumentParser()
@@ -147,12 +148,15 @@ if not os.path.exists("/etc/sudoers.d"):
     os.mkdir("/etc/sudoers.d")
 subprocess.call(["cp", "conf/shutdown", "/etc/sudoers.d/shutdown"])
 
+print("[ CONFIGURING PEACH APT REPO ]")
+setup_peach_deb()
+
+print("[ INSTALLING PEACH MICROSERVICES ]")
+update_microservices()
+
 print("[ PEACHCLOUD SETUP COMPLETE ]")
 print("[ ------------------------- ]")
 print("[ please reboot your device ]")
 
-# TODO: we might also eventually want to pull the `.deb` release files for
-# all microservices and install them. work towards an all-in-one
-# installation script with optional flags to selectively install either
-# the dev environment (will include rust) or a release environment (no
-# rust or other bells and whistles)
+
+# TODO: flags for installing rust, or just the capabilities to run the services

--- a/scripts/setup_networking.py
+++ b/scripts/setup_networking.py
@@ -5,76 +5,89 @@
 # wlan0 and ap0 interfaces. This configuration allows switching between
 # wireless client mode (wlan0) and wireless access point mode (ap0)
 
-import os
 import subprocess
 
-print("[ INSTALLING SYSTEM REQUIREMENTS ]")
-subprocess.call(["apt", "install", "libnss-resolve"])
 
-print("[ DEINSTALLING CLASSIC NETWORKING ]")
-subprocess.call(["apt",
-                 "--autoremove",
-                 "purge",
-                 "ifupdown",
-                 "dhcpcd5",
-                 "isc-dhcp-client",
-                 "isc-dhcp-common",
-                 "rsyslog"])
-subprocess.call(["apt-mark",
-                 "hold",
-                 "ifupdown",
-                 "dhcpcd5",
-                 "isc-dhcp-client",
-                 "isc-dhcp-common",
-                 "rsyslog",
-                 "openresolv"])
-subprocess.call(["rm", "-r", "/etc/network", "/etc/dhcp"])
+def configure_networking():
+    
+    print("[ INSTALLING SYSTEM REQUIREMENTS ]")
+    subprocess.call(["apt", "install", "libnss-resolve"])
 
-print("[ SETTING UP SYSTEMD-RESOLVED & SYSTEMD-NETWORKD ]")
-subprocess.call(["apt", "--autoremove", "purge", "avahi-daemon"])
-subprocess.call(["apt-mark", "hold", "avahi-daemon", "libnss-mdns"])
-subprocess.call(
-    ["ln", "-sf", "/run/systemd/resolve/stub-resolv.conf", "/etc/resolv.conf"])
-subprocess.call(["systemctl",
-                 "enable",
-                 "systemd-networkd.service",
-                 "systemd-resolved.service"])
+    # TODO: confirm with glyph this is supposed to be here
+    print("[ SETTING HOST ]")
+    subprocess.call(["cp", "conf/hostname", "/etc/hostname"])
+    subprocess.call(["cp", "conf/hosts", "/etc/hosts"])
+    
+    print("[ DEINSTALLING CLASSIC NETWORKING ]")
+    subprocess.call(["apt",
+                     "--autoremove",
+                     "purge",
+                     "ifupdown",
+                     "dhcpcd5",
+                     "isc-dhcp-client",
+                     "isc-dhcp-common",
+                     "rsyslog"])
+    subprocess.call(["apt-mark",
+                     "hold",
+                     "ifupdown",
+                     "dhcpcd5",
+                     "isc-dhcp-client",
+                     "isc-dhcp-common",
+                     "rsyslog",
+                     "openresolv"])
+    subprocess.call(["rm", "-rf", "/etc/network", "/etc/dhcp"])
+    
+    print("[ SETTING UP SYSTEMD-RESOLVED & SYSTEMD-NETWORKD ]")
+    subprocess.call(["apt", "--autoremove", "purge", "avahi-daemon"])
+    subprocess.call(["apt-mark", "hold", "avahi-daemon", "libnss-mdns"])
+    subprocess.call(
+        ["ln", "-sf", "/run/systemd/resolve/stub-resolv.conf", "/etc/resolv.conf"])
+    subprocess.call(["systemctl",
+                     "enable",
+                     "systemd-networkd.service",
+                     "systemd-resolved.service"])
+    
+    print("[ CREATING INTERFACE FILE FOR WIRED CONNECTION ]")
+    subprocess.call(["cp", "conf/network/04-wired.network",
+                     "/etc/systemd/network/04-wired.network"])
+    
+    print("[ SETTING UP WPA_SUPPLICANT AS WIFI CLIENT WITH WLAN0 ]")
+    subprocess.call(["cp", "conf/network/wpa_supplicant-wlan0.conf",
+                     "/etc/wpa_supplicant/wpa_supplicant-wlan0.conf"])
+    subprocess.call([
+        "chmod",
+        "600",
+        "/etc/wpa_supplicant/wpa_supplicant-wlan0.conf"])
+    subprocess.call(["systemctl", "disable", "wpa_supplicant.service"])
+    subprocess.call(["systemctl", "enable", "wpa_supplicant@wlan0.service"])
+    
+    print("[ SETTING UP WPA_SUPPLICANT AS ACCESS POINT WITH AP0 ]")
+    subprocess.call(["cp", "conf/network/wpa_supplicant-ap0.conf",
+                     "/etc/wpa_supplicant/wpa_supplicant-ap0.conf"])
+    subprocess.call(
+        ["chmod", "600", "/etc/wpa_supplicant/wpa_supplicant-ap0.conf"])
+    
+    print("[ CONFIGURING INTERFACES ]")
+    subprocess.call(["cp", "conf/network/08-wlan0.network",
+                     "/etc/systemd/network/08-wlan0.network"])
+    subprocess.call(["cp", "conf/network/12-ap0.network",
+                     "/etc/systemd/network/12-ap0.network"])
+    
+    print("[ MODIFYING SERVICE FOR ACCESS POINT TO USE AP0 ]")
+    subprocess.call(["systemctl", "disable", "wpa_supplicant@ap0.service"])
+    subprocess.call(["cp", "conf/network/wpa_supplicant@ap0.service",
+                     "/etc/systemd/system/wpa_supplicant@ap0.service"])
+    
+    print("[ SETTING WLAN0 TO RUN AS CLIENT ON STARTUP ]")
+    subprocess.call(["systemctl", "enable", "wpa_supplicant@wlan0.service"])
+    subprocess.call(["systemctl", "disable", "wpa_supplicant@ap0.service"])
+    
+    print("[ NETWORKING HAS BEEN CONFIGURED ]")
 
-print("[ CREATING INTERFACE FILE FOR WIRED CONNECTION ]")
-subprocess.call(["cp", "conf/network/04-wired.network",
-                 "/etc/systemd/network/04-wired.network"])
 
-print("[ SETTING UP WPA_SUPPLICANT AS WIFI CLIENT WITH WLAN0 ]")
-subprocess.call(["cp", "conf/network/wpa_supplicant-wlan0.conf",
-                 "/etc/wpa_supplicant/wpa_supplicant-wlan0.conf"])
-subprocess.call([
-    "chmod",
-    "600",
-    "/etc/wpa_supplicant/wpa_supplicant-wlan0.conf"])
-subprocess.call(["systemctl", "disable", "wpa_supplicant.service"])
-subprocess.call(["systemctl", "enable", "wpa_supplicant@wlan0.service"])
-
-print("[ SETTING UP WPA_SUPPLICANT AS ACCESS POINT WITH AP0 ]")
-subprocess.call(["cp", "conf/network/wpa_supplicant-ap0.conf",
-                 "/etc/wpa_supplicant/wpa_supplicant-ap0.conf"])
-subprocess.call(
-    ["chmod", "600", "/etc/wpa_supplicant/wpa_supplicant-ap0.conf"])
-
-print("[ CONFIGURING INTERFACES ]")
-subprocess.call(["cp", "conf/network/08-wlan0.network",
-                 "/etc/systemd/network/08-wlan0.network"])
-subprocess.call(["cp", "conf/network/12-ap0.network",
-                 "/etc/systemd/network/12-ap0.network"])
-
-print("[ MODIFYING SERVICE FOR ACCESS POINT TO USE AP0 ]")
-subprocess.call(["systemctl", "disable", "wpa_supplicant@ap0.service"])
-subprocess.call(["cp", "conf/network/wpa_supplicant@ap0.service",
-                 "/etc/systemd/system/wpa_supplicant@ap0.service"])
-
-print("[ SETTING WLAN0 TO RUN AS CLIENT ON STARTUP ]")
-subprocess.call(["systemctl", "enable", "wpa_supplicant@wlan0.service"])
-subprocess.call(["systemctl", "disable", "wpa_supplicant@ap0.service"])
-
-print("[ NETWORKING HAS BEEN CONFIGURED ]")
-print("[ ------------------------------ ]")
-print("[ please reboot your device now. ]")
+if __name__ == '__main__':
+    
+    configure_networking()
+    
+    print("[ ------------------------------ ]")
+    print("[ please reboot your device now. ]")

--- a/scripts/setup_peach_deb.py
+++ b/scripts/setup_peach_deb.py
@@ -1,0 +1,23 @@
+# setup_peach_deb.py
+# Standalone script to configure a Debian installation to add the peach apt repository
+# and install all peach microservices to the latest version
+
+import subprocess
+
+from update_microservices import update_microservices
+
+
+def setup_peach_deb():
+    """
+    Adds apt.peachcloud.org to the list of debian apt sources and sets the public key appropriately
+    """
+    subprocess.call(["cp", "conf/peach.list", "/etc/apt/sources.list.d/peach.list"])
+    # add public key
+    subprocess.call(["wget", "-O", "/srv/pubkey.gpg", "http://apt.peachcloud.org/pubkey.gpg"])
+    subprocess.call(["apt-key", "add", "/srv/pubkey.gpg"])
+    subprocess.call(["rm", "/srv/pubkey.gpg"])
+
+
+if __name__ == '__main__':
+    setup_peach_deb()
+    update_microservices()

--- a/scripts/update_microservices.py
+++ b/scripts/update_microservices.py
@@ -1,0 +1,39 @@
+import subprocess
+import argparse
+
+
+def update_microservices(purge=False):
+    """
+    installs all peach microservices
+    or updates them to the latest version
+    :param purge: if provided, purges all microservices before re-installing them
+    :return: None
+    """
+    subprocess.call(['apt-get', 'update'])
+
+    SERVICES = [
+        "peach-oled",
+        "peach-network",
+        "peach-stats",
+        "peach-web",
+        "peach-menu",
+        "peach-buttons",
+        "peach-monitor",
+    ]
+
+    for service in SERVICES:
+        if purge:
+            print('[ removing {} ]'.format(service))
+            subprocess.call(['apt-get', 'remove', service])
+            subprocess.call(['apt-get', 'purge', service])
+        print('[ installing {} ]'.format(service))
+        subprocess.call(['apt-get', 'install', service])
+
+
+if __name__ == '__main__':
+    # Setup argument parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--purge", help="update microservices and purge old installations", action="store_true")
+    args = parser.parse_args()
+
+    update_microservices(purge=args.purge)


### PR DESCRIPTION
The script was mostly idempotent already so only a couple changes. 
- add -f flag to rm commands (so it doesn't complain if directory already doesn't exist)
- add -f flag to ln command (so it idempotently overwrites target file already exists)

I also refactored the network configuration into a function, which then gets called by setup_dev_env.py and also by setup_networking when its run as a standalone script 

There are still a few commands in the script that throw warnings because the thing already exists 
e.g. useradd and groupadd 
... but they still run so its ok, and maybe the warnings are helpful information?
We could also write wrapper functions for these calls, so that if it already exists its just silent instead of throwing a warning

Additional questions/thoughts that maybe we can just chat about on the call tomorrow:

is /etc/wpa_supplicant/wpa_supplicant.conf  deprecated now, in favor of /etc/wpa_supplicant/wpa_supplicant-wlan0.conf? and so should /etc/wpa_supplicant/wpa_supplicant.conf not exist?

maybe the setup script shouldn't overwrite 
/etc/wpa_supplicant/wpa_supplicant-wlan0.conf if it exists,
to avoid overrwriting previous credentials 

a related question, 
I've been wondering about
"export data" functionality for peach cloud
... basically I'm wondering if there's a way we could establish a pattern to store all Peach state (even wifi credentials) in a peach.json somewhere... and then as part of setup_dev_env this could take peach.json as an input... and rebuild the system files appropriately.... this pattern could have the advantage to make setup_dev_env more robust & repeatable, while also preparing the way for import/export of peach state (for moving to a new device, or reflashing the current device which could also be useful for fixing a device thats gotten to a weird unknown state)

