### PR TITLE
Add scripts for adding peach apt repo and installing/updating microservices

### DIFF
--- a/conf/peach.list
+++ b/conf/peach.list
@@ -1,0 +1,1 @@
+deb http://apt.peachcloud.org/ buster main

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -7,10 +7,11 @@
 
 import os
 import subprocess
-import sys
 import argparse
 
 from setup_networking import configure_networking
+from setup_peach_deb import setup_peach_deb
+from update_microservices import update_microservices
 
 # Setup argument parser
 parser = argparse.ArgumentParser()
@@ -147,12 +148,15 @@ if not os.path.exists("/etc/sudoers.d"):
     os.mkdir("/etc/sudoers.d")
 subprocess.call(["cp", "conf/shutdown", "/etc/sudoers.d/shutdown"])
 
+print("[ CONFIGURING PEACH APT REPO ]")
+setup_peach_deb()
+
+print("[ INSTALLING PEACH MICROSERVICES ]")
+update_microservices()
+
 print("[ PEACHCLOUD SETUP COMPLETE ]")
 print("[ ------------------------- ]")
 print("[ please reboot your device ]")
 
-# TODO: we might also eventually want to pull the `.deb` release files for
-# all microservices and install them. work towards an all-in-one
-# installation script with optional flags to selectively install either
-# the dev environment (will include rust) or a release environment (no
-# rust or other bells and whistles)
+
+# TODO: flags for installing rust, or just the capabilities to run the services

--- a/scripts/setup_peach_deb.py
+++ b/scripts/setup_peach_deb.py
@@ -1,0 +1,23 @@
+# setup_peach_deb.py
+# Standalone script to configure a Debian installation to add the peach apt repository
+# and install all peach microservices to the latest version
+
+import subprocess
+
+from update_microservices import update_microservices
+
+
+def setup_peach_deb():
+    """
+    Adds apt.peachcloud.org to the list of debian apt sources and sets the public key appropriately
+    """
+    subprocess.call(["cp", "conf/peach.list", "/etc/apt/sources.list.d/peach.list"])
+    # add public key
+    subprocess.call(["wget", "-O", "/srv/pubkey.gpg", "http://apt.peachcloud.org/pubkey.gpg"])
+    subprocess.call(["apt-key", "add", "/srv/pubkey.gpg"])
+    subprocess.call(["rm", "/srv/pubkey.gpg"])
+
+
+if __name__ == '__main__':
+    setup_peach_deb()
+    update_microservices()

--- a/scripts/update_microservices.py
+++ b/scripts/update_microservices.py
@@ -12,28 +12,25 @@ def update_microservices(purge=False):
     subprocess.call(['apt-get', 'update'])
 
     SERVICES = [
-        {"name": "peach-oled", "repo_url": "https://github.com/peachcloud/peach-oled.git"},
-        {"name": "peach-network", "repo_url": "https://github.com/peachcloud/peach-network.git"},
-        {"name": "peach-stats", "repo_url": "https://github.com/peachcloud/peach-stats.git"},
-        {"name": "peach-web", "repo_url": "https://github.com/peachcloud/peach-web.git"},
-        {"name": "peach-menu", "repo_url": "https://github.com/peachcloud/peach-menu.git"},
-        {"name": "peach-buttons", "repo_url": "https://github.com/peachcloud/peach-buttons.git"},
-        {"name": "peach-monitor", "repo_url": "https://github.com/peachcloud/peach-monitor.git"}
+        "peach-oled",
+        "peach-network",
+        "peach-stats",
+        "peach-web",
+        "peach-menu",
+        "peach-buttons",
+        "peach-monitor",
     ]
 
     for service in SERVICES:
-        name = service['name']
         if purge:
-            print('[ removing {} ]'.format(name))
-            subprocess.call(['apt-get', 'remove', name])
-            subprocess.call(['apt-get', 'purge', name])
-        print('[ installing {} ]'.format(name))
-        subprocess.call(['apt-get', 'install', name])
-
+            print('[ removing {} ]'.format(service))
+            subprocess.call(['apt-get', 'remove', service])
+            subprocess.call(['apt-get', 'purge', service])
+        print('[ installing {} ]'.format(service))
+        subprocess.call(['apt-get', 'install', service])
 
 
 if __name__ == '__main__':
-
     # Setup argument parser
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--purge", help="update microservices and purge old installations", action="store_true")

--- a/scripts/update_microservices.py
+++ b/scripts/update_microservices.py
@@ -1,0 +1,42 @@
+import subprocess
+import argparse
+
+
+def update_microservices(purge=False):
+    """
+    installs all peach microservices
+    or updates them to the latest version
+    :param purge: if provided, purges all microservices before re-installing them
+    :return: None
+    """
+    subprocess.call(['apt-get', 'update'])
+
+    SERVICES = [
+        {"name": "peach-oled", "repo_url": "https://github.com/peachcloud/peach-oled.git"},
+        {"name": "peach-network", "repo_url": "https://github.com/peachcloud/peach-network.git"},
+        {"name": "peach-stats", "repo_url": "https://github.com/peachcloud/peach-stats.git"},
+        {"name": "peach-web", "repo_url": "https://github.com/peachcloud/peach-web.git"},
+        {"name": "peach-menu", "repo_url": "https://github.com/peachcloud/peach-menu.git"},
+        {"name": "peach-buttons", "repo_url": "https://github.com/peachcloud/peach-buttons.git"},
+        {"name": "peach-monitor", "repo_url": "https://github.com/peachcloud/peach-monitor.git"}
+    ]
+
+    for service in SERVICES:
+        name = service['name']
+        if purge:
+            print('[ removing {} ]'.format(name))
+            subprocess.call(['apt-get', 'remove', name])
+            subprocess.call(['apt-get', 'purge', name])
+        print('[ installing {} ]'.format(name))
+        subprocess.call(['apt-get', 'install', name])
+
+
+
+if __name__ == '__main__':
+
+    # Setup argument parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--purge", help="update microservices and purge old installations", action="store_true")
+    args = parser.parse_args()
+
+    update_microservices(purge=args.purge)


### PR DESCRIPTION
While I was updating peach-config, this seemed like a good time to add peach apt integration and a script for updating the microservices. 

This PR includes:
- adds setup_peach_deb.py script which creates a file pointing to apt.peachcloud.org in /etc/apt/sources.list.d/peach.list, and adds the necessary apt-key
- adds update_microservices.py script which installs all peach microservices using apt (or updates them  to latest versions if they already are installed)
- adds calls to both of these functions to the end of setup_dev_env.py

Also had a question. To add the apt pubkey, I downloaded the key to the temporary location /srv/pubkey.pgp ... was wondering what you think is a good location for a temporary download which will be cleaned up afterwards? Is /tmp guaranteed to exist?