### PR TITLE
Add missing commas, move configure networking to last step

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# exit when any command fails
+KEY_FILE="/Users/maxfowler/.ssh/peach_rsa"
+
+# deploy
+echo "++ copying files to pi"
+rsync -avzh --exclude target --exclude .idea --exclude .git -e "ssh -i $KEY_FILE" . peach@peach.link:/srv/peach-config
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# exit when any command fails
-KEY_FILE="/Users/maxfowler/.ssh/peach_rsa"
-
-# deploy
-echo "++ copying files to pi"
-rsync -avzh --exclude target --exclude .idea --exclude .git -e "ssh -i $KEY_FILE" . peach@peach.link:/srv/peach-config
-

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -126,9 +126,6 @@ if args.rtc and args.i2c:
     subprocess.call(["systemctl", "daemon-reload"])
     subprocess.call(["systemctl", "enable", "activate-rtc"])
 
-# configure networking via setup_networking.py
-configure_networking()
-
 print("[ CONFIGURING NGINX ]")
 subprocess.call(
     ["cp", "conf/peach.conf", "/etc/nginx/sites-available/peach.conf"])
@@ -153,6 +150,9 @@ setup_peach_deb()
 
 print("[ INSTALLING PEACH MICROSERVICES ]")
 update_microservices()
+
+# configure networking via setup_networking.py
+configure_networking()
 
 print("[ PEACHCLOUD SETUP COMPLETE ]")
 print("[ ------------------------- ]")

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -63,7 +63,7 @@ subprocess.call(["apt-get",
                  "i2c-tools",
                  "build-essential",
                  "curl",
-                 "libnss-resolve"
+                 "libnss-resolve",
                  "mosh",
                  "sudo",
                  "pkg-config",

--- a/scripts/setup_dev_env.py
+++ b/scripts/setup_dev_env.py
@@ -41,7 +41,7 @@ users = [
     "peach-buttons",
     "peach-menu",
     "peach-monitor",
-    "peach-network"
+    "peach-network",
     "peach-oled",
     "peach-stats",
     "peach-web"]


### PR DESCRIPTION
This PR:
- adds missing commas to list of users to create and packages to install
- moves configure_networking to the last step of setup_dev_env so that networking is still available throughout the rest of the script

I guess these bugs sneaked in because we tested setup_dev_env by re-running it on an already configured machine, instead of running it on a fresh machine, 
and because the setup_dev_env script throws silent errors and keeps going. 

It could be worth re-visiting this to avoid future headaches, and refactor the script to fail if anything throws an error.

As I've been reading about disc images, I've also been looking at ways of virtualizing a raspberry pi, which could be an interesting thing to look into for more quickly testing setup/install scripts on fresh installs so that we can confirm the scripts work on a fresh install before merging to master. 