### PR TITLE
Script which runs on boot and copies /boot/firmware/wpa_supplicant.conf if it exists

### DIFF
--- a/conf/config.txt_i2c
+++ b/conf/config.txt_i2c
@@ -8,7 +8,7 @@ dtparam=i2c_arm=on
 # Apply device tree overlay to enable pull-up resistors for buttons
 device_tree_overlay=overlays/mygpio.dtbo
 
-kernel=vmlinuz-4.19.0-13-arm64
+kernel=vmlinuz-4.19.0-14-arm64
 # For details on the initramfs directive, see
 # https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=10532
-initramfs initrd.img-4.19.0-13-arm64
+initramfs initrd.img-4.19.0-14-arm64

--- a/conf/network/copy-wlan.service
+++ b/conf/network/copy-wlan.service
@@ -1,0 +1,8 @@
+[Unit]
+Before=network.target
+
+[Service]
+ExecStart=/usr/local/bin/copy-wlan.sh
+
+[Install]
+WantedBy=default.target

--- a/conf/network/copy-wlan.sh
+++ b/conf/network/copy-wlan.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+FILE=/boot/firmware/wpa_supplicant.conf
+if test -f "$FILE"; then
+    cp /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
+    chown root:netdev /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
+    rm /boot/firmware/wpa_supplicant.conf
+fi

--- a/conf/network/copy-wlan.sh
+++ b/conf/network/copy-wlan.sh
@@ -2,7 +2,7 @@
 
 FILE=/boot/firmware/wpa_supplicant.conf
 if test -f "$FILE"; then
-    cp /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
+    cp $FILE /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
     chown root:netdev /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
-    rm /boot/firmware/wpa_supplicant.conf
+    rm $FILE
 fi

--- a/scripts/setup_networking.py
+++ b/scripts/setup_networking.py
@@ -64,6 +64,12 @@ def configure_networking():
     subprocess.call(["systemctl", "disable", "wpa_supplicant.service"])
     subprocess.call(["systemctl", "enable", "wpa_supplicant@wlan0.service"])
 
+    print("[ CREATING BOOT SCRIPT TO COPY NETWORK CONFIGS ]")
+    subprocess.call(["cp", "conf/network/copy-wlan.sh", "/usr/local/bin/copy-wlan.sh"])
+    subprocess.call(["chmod", "770", "/usr/local/bin/copy-wlan.s"])
+    subprocess.call(["cp", "conf/network/copy-wlan.service", "/etc/systemd/system/copy-wlan.service"])
+    subprocess.call(["systemctl", "enable", "copy-wlan.service"])
+
     print("[ SETTING UP WPA_SUPPLICANT AS ACCESS POINT WITH AP0 ]")
     subprocess.call(["cp", "conf/network/wpa_supplicant-ap0.conf",
                      "/etc/wpa_supplicant/wpa_supplicant-ap0.conf"])

--- a/scripts/setup_networking.py
+++ b/scripts/setup_networking.py
@@ -66,7 +66,7 @@ def configure_networking():
 
     print("[ CREATING BOOT SCRIPT TO COPY NETWORK CONFIGS ]")
     subprocess.call(["cp", "conf/network/copy-wlan.sh", "/usr/local/bin/copy-wlan.sh"])
-    subprocess.call(["chmod", "770", "/usr/local/bin/copy-wlan.s"])
+    subprocess.call(["chmod", "770", "/usr/local/bin/copy-wlan.sh"])
     subprocess.call(["cp", "conf/network/copy-wlan.service", "/etc/systemd/system/copy-wlan.service"])
     subprocess.call(["systemctl", "enable", "copy-wlan.service"])
 


### PR DESCRIPTION
This script checks if a file is found at /boot/firmware/wpa_supplicant.conf and if so it copies it to /etc/wpa_supplicant/wpa_supplicant-wlan0.conf

The script is set to run on boot, using systemd. 

I'm back to using Mac OS again, so this is useful to me again, and figured its a good thing to have in the future anyway. 

I'm back on mac again, because I had to update mac OS on my dual boot, in order to test publishing the ios app for hyphalfusion, and the latest version of mac os is currently incompatible with the dual boot system I was using. 

So debian is still technically on my laptop, I just cant' boot into it lol. 
I'm actually just going to wait a bit, and see if the person who maintains Refind (a dual boot tool for mac + linux) eventually releases a version that is compatible with the latest mac OS. 

But anyway, this script is working in the meantime. 