### PR TITLE
Fix README and add install_peach_config.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ wget -O - http://apt.peachcloud.org/pubkey.gpg | sudo apt-key add -
 You can then install peach-config with apt:
 
 ``` bash
-sudo apt update
-sudo apt install peach-config
+sudo apt-get update
+sudo apt-get install python3-peach-config
 ```
 
 peach-config has only been tested on a Raspberry Pi 3 B+ running Debian 10. 

--- a/install_peach_config.sh
+++ b/install_peach_config.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+echo "deb http://apt.peachcloud.org/ buster main" > /etc/apt/sources.list.d/peach.list
+wget -O - http://apt.peachcloud.org/pubkey.gpg | sudo apt-key add -
+apt-get update
+apt-get install -y python3-peach-config


### PR DESCRIPTION
As discussed, this add s the install_peach_config.sh script, which I've confirmed can be run as a one-liner, like:
```
wget -O - https://raw.githubusercontent.com/peachcloud/peach-config/070895cfebaa5bf88ae62b514a89609f1a807cdd/install_peach_config.sh | bash
```
(of course with whatever link we would actually put the script at)

However, now that I'm looking at it, and see that the script is only 4 lines. 
Maybe its better in the documentation wherever this is needed to just include these four lines for people to run themselves. 

As its quite short, and downloading and running a script in one line might just be unnecessary and weird security. 
Or we can just merge this script into the repo, but decide later when to suggest downloading the script, vs just suggest running the four lines. 