### PR TITLE
setup and manifest subcommands for peach-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 deploy.sh
 .idea
+__pycache__

--- a/peach_config/generate_manifest.py
+++ b/peach_config/generate_manifest.py
@@ -3,10 +3,12 @@ import sys
 import re
 import json
 
+from peach_config.utils import load_hardware_config
+
 
 def get_currently_installed_microservices():
-    packages = subprocess.check_output(["apt", "list", "--installed"]).decode(sys.stdout.encoding).strip()
-    peach_packages = re.finditer(r'(\S+)/buster,now (\S+) \S+.*\n', packages)
+    packages = subprocess.check_output(["dpkg", "-l"]).decode(sys.stdout.encoding).strip()
+    peach_packages = re.finditer(r'\S+\s+(\S*peach\S+)\s+(\S+).*\n', packages)
     package_dict = {}
     for package in peach_packages:
         package_dict[package.group(1)] = package.group(2)
@@ -15,19 +17,14 @@ def get_currently_installed_microservices():
     return package_dict
 
 
-def get_last_installed_hardware_configuration():
-    return {
-        "i2c": True,
-        "rtc": "ds123"
-    }
-
-
 def generate_manifest():
     packages = get_currently_installed_microservices()
-    configuration = get_last_installed_hardware_configuration()
+    hardware_config = load_hardware_config()
+    if not hardware_config:
+        hardware_config = "No PeachCloud hardware config found"
     manifest = {
         "packages": packages,
-        "hardware": configuration
+        "hardware": hardware_config,
     }
     print(json.dumps(manifest))
 

--- a/peach_config/generate_manifest.py
+++ b/peach_config/generate_manifest.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+import re
+import json
+
+
+def get_currently_installed_microservices():
+    packages = subprocess.check_output(["apt", "list", "--installed"]).decode(sys.stdout.encoding).strip()
+    peach_packages = re.finditer(r'(\S+)/buster,now (\S+) \S+.*\n', packages)
+    package_dict = {}
+    for package in peach_packages:
+        package_dict[package.group(1)] = package.group(2)
+
+    # return dictionary mapping package name to version
+    return package_dict
+
+
+def get_last_installed_hardware_configuration():
+    return {
+        "i2c": True,
+        "rtc": "ds123"
+    }
+
+
+def generate_manifest():
+    packages = get_currently_installed_microservices()
+    configuration = get_last_installed_hardware_configuration()
+    manifest = {
+        "packages": packages,
+        "hardware": configuration
+    }
+    print(json.dumps(manifest))
+
+
+if __name__ == '__main__':
+    generate_manifest()

--- a/peach_config/main.py
+++ b/peach_config/main.py
@@ -1,0 +1,33 @@
+"""
+this file is the main entrypoint to all the peach-config CLI subcommands
+"""
+import sys
+import argparse
+
+from peach_config.generate_manifest import generate_manifest
+from peach_config.setup_peach import init_setup_parser, setup_peach
+
+
+def peach_config():
+
+    # create parser
+    parser = argparse.ArgumentParser(prog='peach-config')
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+
+    # create parsers for subcommands
+    setup_parser = subparsers.add_parser('setup', help="idempotent setup of PeachCloud")
+    init_setup_parser(setup_parser)
+    subparsers.add_parser('manifest', help='prints manifest of peach configurations')
+
+    # parse arguments
+    args = parser.parse_args()
+
+    # switch based on subcommand
+    if args.subcommand == 'setup':
+        setup_peach(parser)
+    elif args.subcommand == 'manifest':
+        generate_manifest()
+
+
+if __name__ == '__main__':
+    sys.exit(peach_config())

--- a/peach_config/setup_peach.py
+++ b/peach_config/setup_peach.py
@@ -9,15 +9,18 @@ import os
 import subprocess
 import argparse
 import crypt
+import sys
+
 
 from peach_config.constants import PROJECT_PATH
 from peach_config.setup_networking import configure_networking
 from peach_config.setup_peach_deb import setup_peach_deb
 from peach_config.update_microservices import update_microservices
+from peach_config.utils import save_hardware_config
 
-def main():
+
+def init_setup_parser(parser):
     # Setup argument parser
-    parser = argparse.ArgumentParser()
     parser.add_argument(
         "user",
         type=str,
@@ -32,6 +35,12 @@ def main():
             "ds1307",
             "ds3231"],
         help="configure real-time clock")
+    return parser
+
+
+def setup_peach(parser):
+
+    # parse args from parser
     args = parser.parse_args()
 
     # Ensure RTC configuration requirements are met (if selected)
@@ -178,12 +187,12 @@ def main():
     # configure networking via setup_networking.py
     configure_networking()
 
+    # save hardware configuration as a json
+    save_hardware_config(i2c=args.i2c, rtc=args.rtc)
+
     print("[ PEACHCLOUD SETUP COMPLETE ]")
     print("[ ------------------------- ]")
     print("[ please reboot your device ]")
 
-
-if __name__ == '__main__':
-    sys.exit(main())
 
 

--- a/peach_config/utils.py
+++ b/peach_config/utils.py
@@ -1,0 +1,32 @@
+import json
+import os
+
+
+PEACH_DATA_DIR = "/var/lib/peachcloud/"
+HARDWARE_CONFIG_FILE = os.path.join(PEACH_DATA_DIR, "hardware_config.json")
+
+
+def save_hardware_config(i2c, rtc):
+    """
+    helper function to store what hardware configuration a particular peach was setup with
+    """
+    hardware_config = {
+        "i2c": i2c,
+        "rtc": rtc
+    }
+    if not os.path.exists(PEACH_DATA_DIR):
+        os.makedirs(PEACH_DATA_DIR)
+    with open(HARDWARE_CONFIG_FILE, 'w') as f:
+        f.write(json.dumps(hardware_config))
+
+
+def load_hardware_config():
+    """
+    helper function to load the hardware configuration used last time setup_peach.py successfully ran
+    """
+    if os.path.exists(HARDWARE_CONFIG_FILE):
+        with open(HARDWARE_CONFIG_FILE, 'r') as f:
+            hardware_config = json.loads(f.read())
+        return hardware_config
+    else:
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+simplejson==3.17.2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     include_package_data=True,
     entry_points = {
         'console_scripts' : [
-            'peach-config = peach_config.setup_peach:main',
+            'peach-config = peach_config.main:peach_config',
         ]
     },
     classifiers=[


### PR DESCRIPTION
we can further confirm the rest of the API, as started in this issue https://github.com/peachcloud/peach-config/issues/34

but for now, I've added subcommands for:
- setup
- manifest 

This whole rabbit hole I've gone down this week (which I hope will be worthwhile in the end), was actually really to get this manifest subcommand, 
so that I could use this manifest subcommand at the end of peach-img-builder, 
to store and display exactly what was installed in that particular image. 