### PR TITLE
Add update --list command and fix bugs

### DIFF
--- a/peach_config/constants.py
+++ b/peach_config/constants.py
@@ -1,3 +1,16 @@
 import os
 
 PROJECT_PATH = os.path.dirname(os.path.realpath(__file__))
+
+SERVICES = [
+    "peach-oled",
+    "peach-network",
+    "peach-stats",
+    "peach-web",
+    "peach-menu",
+    "peach-buttons",
+    "peach-monitor",
+    "peach-probe",
+    "peach-go-sbot",
+    "python3-peach-config"
+]

--- a/peach_config/main.py
+++ b/peach_config/main.py
@@ -6,7 +6,7 @@ import argparse
 
 from peach_config.generate_manifest import generate_manifest
 from peach_config.setup_peach import init_setup_parser, setup_peach
-from peach_config.update import init_update_parser, update_microservices
+from peach_config.update import init_update_parser, update
 
 
 def peach_config():
@@ -31,7 +31,7 @@ def peach_config():
     elif args.subcommand == 'manifest':
         generate_manifest()
     elif args.subcommand == 'update':
-        update_microservices(parser)
+        update(parser)
 
 
 if __name__ == '__main__':

--- a/peach_config/setup_peach_deb.py
+++ b/peach_config/setup_peach_deb.py
@@ -6,7 +6,7 @@ import subprocess
 import os
 
 from peach_config.constants import PROJECT_PATH
-from peach_config.update_microservices import update_microservices
+from peach_config.update import update_microservices
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name = "peach-config",
-    version = "0.2.11",
+    version = "0.2.13",
     author = "Andrew Reid",
     author_email = "gnomad@cryptolab.net",
     description = "Python package for configuring and updating PeachCloud",


### PR DESCRIPTION
My last update PR actually had some bugs, from an interesting source!

I had been testing the code by running it as python directly on the pi, 
but I believe if you are running python on the pi, 
and you have the peach-config freight module installed,
python may still end up running the code from the module, and not the code you are actually writing, due to python path issues, and the fact that python3-peach-config is actually running on the pi as python! which means if your python code imports something from peach_config it might get the freight code. Hopefully that explanation makes sense -- basically a pythonpath issue that can come up during development. If you are trying to develop peach-config on the pi, its probably best to temporarily uninstall the peach-config freight module while doing development. 

This PR fixes those import bugs (from the refactor), 
and adds a command `peach-config update --list` which lists available PeachCloud updates without running them. 

We can update this API further in the future when its actually needed by peach-web. 