### PR TITLE
Remove creation of peach-network system user

### DIFF
--- a/peach_config/setup_peach.py
+++ b/peach_config/setup_peach.py
@@ -46,7 +46,6 @@ def main():
         "peach-buttons",
         "peach-menu",
         "peach-monitor",
-        "peach-network",
         "peach-oled",
         "peach-stats",
         "peach-web"]


### PR DESCRIPTION
`peach-network` system user is no longer needed due to the change in service privileges (now running as `root:netdev`).