### PR TITLE
Add subcommand to reset peach folder permissions

### DIFF
--- a/peach_config/main.py
+++ b/peach_config/main.py
@@ -23,6 +23,7 @@ def peach_config():
     subparsers.add_parser('manifest', help='prints manifest of peach configurations')
     update_parser = subparsers.add_parser('update', help='updates all PeachCloud microservices')
     init_update_parser(update_parser)
+    subparsers.add_parser('permissions', help="reset user permissions for all folder on peachcloud device")
 
     # parse arguments
     args = parser.parse_args()

--- a/peach_config/main.py
+++ b/peach_config/main.py
@@ -5,7 +5,8 @@ import sys
 import argparse
 
 from peach_config.generate_manifest import generate_manifest
-from peach_config.setup_peach import init_setup_parser, setup_peach_from_parser, reconfigure_peach
+from peach_config.setup_peach import init_setup_parser, setup_peach_from_parser, \
+    reconfigure_peach, set_peach_permissions
 from peach_config.update import init_update_parser, update
 
 
@@ -29,6 +30,8 @@ def peach_config():
     # switch based on subcommand
     if args.subcommand == 'setup':
         setup_peach_from_parser(parser)
+    if args.subcommand == 'permissions':
+        set_peach_permissions()
     elif args.subcommand == 'manifest':
         generate_manifest()
     elif args.subcommand == 'update':

--- a/peach_config/setup_peach.py
+++ b/peach_config/setup_peach.py
@@ -73,6 +73,27 @@ def setup_peach_from_parser(parser):
     )
 
 
+def set_permissions(path):
+    """
+    helper function which sets read/write permissions for files
+    and read/write/execute permissions for folders
+    see https://superuser.com/questions/91935/how-to-recursively-chmod-all-directories-except-files
+    """
+    subprocess.check_call(["chmod", "-R", "u+rwX,go+rX,go-w", path])
+
+
+def set_peach_permissions():
+    """
+    resets correct permissions in all folders across the peach device
+    """
+    # peachcloud data
+    print("[ RESETTING PEACH FOLDER PERMISSIONS ]")
+    data_dir = "/var/lib/peachcloud"
+    subprocess.check_call(["chown", "-R", "peach-web", data_dir])
+    subprocess.check_call(["chgrp", "-R", "peach", data_dir])
+    set_permissions(data_dir)
+
+
 def setup_peach(i2c, rtc, no_input=False, default_locale=False):
     """
     idempotent function which sets up all peach configuration

--- a/peach_config/setup_peach.py
+++ b/peach_config/setup_peach.py
@@ -92,6 +92,7 @@ def set_peach_permissions():
     subprocess.check_call(["chown", "-R", "peach-web", data_dir])
     subprocess.check_call(["chgrp", "-R", "peach", data_dir])
     set_permissions(data_dir)
+    print("[ PERMISSIONS SUCCESSFULLY RESET ]")
 
 
 def setup_peach(i2c, rtc, no_input=False, default_locale=False):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name = "peach-config",
-    version = "0.2.17",
+    version = "0.2.18",
     author = "Andrew Reid",
     author_email = "gnomad@cryptolab.net",
     description = "Python package for configuring and updating PeachCloud",


### PR DESCRIPTION
While working on peach-web, I started running into a permissions issue where some of the files in /var/lib/peachcloud/ had gotten the wrong permissions (probably from human error on my part)

I could have just manually reset the permissions, but I thought it might be useful to have a command in peach-config which specifically does this, so that if permissions get weird for any reason, you just call this command, and hopefully it resets all permissions of folders to what they should be. This could also possibly be exposed through peach-web in some type of troubleshooting screen. 

does this seem like an ok subcommand? anything I'm missing? @mycognosist 